### PR TITLE
feat: Add bower.json for publishing package in Bower registery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Source can be loaded via [npm](https://www.npmjs.com/package/i18next-fetch-backe
 ```
 # npm package
 $ npm install --save i18next-fetch-backend
+
+# bower
+$ bower install --save i18next-fetch-backend
 ```
 
 Wiring up:

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "i18next-fetch-backend",
+  "description": "backend layer for i18next using browsers fetch",
+  "main": "lib/index.js",
+  "authors": [
+    "Julian Grinblat <julian@dotcore.co.il>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "i18next",
+    "i18next-backend"
+  ],
+  "homepage": "https://github.com/perrin4869/i18next-fetch-backend",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
See #8: This PR adds bower.json so that you can publish this package in the Bower registery. After this package has merged, you can  publish the package following [the instructions over here](https://bower.io/docs/creating-packages/#register).