### PR TITLE
Call the callback when the fetch rejects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,8 @@ class Backend {
         }
 
         return response.text();
+      }, () => {
+        return callback(`failed loading ${url}`, false);
       })
       .then((data) => {
         try {

--- a/test/index.js
+++ b/test/index.js
@@ -75,4 +75,24 @@ describe('i18next-fetch-backend', () => {
         cb();
       });
   });
+
+  it('should call the callback with an error if the fetch fails.', (cb) => {
+    const i18next = createInstance();
+
+    i18next
+      .use(FetchBackend)
+      .init({
+        fallbackLng: 'en',
+        ns: 'translation',
+        backend: {
+          loadPath: 'http://localhost:3000/{{lng}}/{{ns}}.json',
+          // mock fetch with a function that returns a rejection of cancelled request
+          fetch: () => Promise.reject(new TypeError('cancelled'))
+        }
+      }, (err) => {
+        expect(err).to.deep.equal(['failed loading http://localhost:3000/en/translation.json']);
+
+        cb();
+      });
+  });
 });


### PR DESCRIPTION
This ensures that the callback is executed if the fetch is cancelled by the browser. When this happens, the fetch returns a rejected Promise, which should be handled by the callback.