### PR TITLE
restrict 'failed loading' error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,15 +69,16 @@ class Backend {
         }
 
         return response.text();
-      })
+      }, () => callback(`failed loading ${url}`, false))
       .then((data) => {
         try {
-          return callback(null, parse(data, url));
+          if (data) {
+            return callback(null, parse(data, url));
+          }
         } catch (e) {
           return callback(`failed parsing ${url} to json`, false);
         }
-      })
-      .catch(() => callback(`failed loading ${url}`, false));
+      });
   }
 
   create(languages, namespace, key, fallbackValue) {

--- a/src/index.js
+++ b/src/index.js
@@ -65,16 +65,19 @@ class Backend {
           let retry = false; // status codes 4xx
           if (status >= 500 && status < 600) retry = true;
 
-          return callback(`failed loading ${url}`, retry);
+          callback(`failed loading ${url}`, retry);
+          return null;
         }
 
         return response.text();
-      }, () => callback(`failed loading ${url}`, false))
+      }, () => {
+        callback(`failed loading ${url}`, null);
+        return null;
+      })
       .then((data) => {
+        if (data === null) return undefined;
         try {
-          if (data) {
-            return callback(null, parse(data, url));
-          }
+          return callback(null, parse(data, url));
         } catch (e) {
           return callback(`failed parsing ${url} to json`, false);
         }

--- a/test/index.js
+++ b/test/index.js
@@ -82,6 +82,8 @@ describe('i18next-fetch-backend', () => {
     );
   });
 
+
+
   it("should fail if the requested domain doesn't exist", (cb) => {
     const i18next = createInstance();
 
@@ -101,5 +103,25 @@ describe('i18next-fetch-backend', () => {
         cb();
       },
     );
+  });
+
+  it('should call the callback with an error if the fetch fails.', (cb) => {
+    const i18next = createInstance();
+
+    i18next
+      .use(FetchBackend)
+      .init({
+        fallbackLng: 'en',
+        ns: 'translation',
+        backend: {
+          loadPath: 'http://localhost:3000/{{lng}}/{{ns}}.json',
+          // mock fetch with a function that returns a rejection of cancelled request
+          fetch: () => Promise.reject(new TypeError('cancelled'))
+        }
+      }, (err) => {
+        expect(err).to.deep.equal(['failed loading http://localhost:3000/en/translation.json']);
+
+        cb();
+      });
   });
 });


### PR DESCRIPTION
The 'failed loading' error now only happens when the response is not ok or the fetch Promise rejects.

Before, the 'failed loading' error would also apply to a rejection or error in the first or second `then` calls. This wasn't ideal because it misrepresents what is happening.

Replaces #19.