### PR TITLE
Fix missing import in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { BackendModule, Services, ReadCallback } from 'i18next';
+import { BackendModule, Services, ReadCallback, InitOptions } from 'i18next';
 
 export interface FetchOptions {
   loadPath: string,


### PR DESCRIPTION
Fixing missing Import of `InitOptions` that caused tsc errors as:

```
node_modules/i18next-fetch-backend/index.d.ts:18:74 - error TS2304: Cannot find name 'InitOptions'.

18   init(services: Services, backendOptions: FetchOptions, i18nextOptions: InitOptions): void;

Found 1 error.
```